### PR TITLE
feat: add option to disable d3 transitions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ myChart
 | <b>onHover</b>([<i>fn</i>]) | Callback function for mouse hover events. Includes the data node object (or `null` if hovering on background) as single argument. | |
 | <b>onClick</b>([<i>fn</i>]) | Callback function for click events. Includes the data node object (or `null` if clicking on background) as single argument. A falsy value (default) automatically zooms on clicked nodes, equivalent to `myChart.onClick(myChart.zoomToNode)`. | |
 | <b>transitionDuration</b>([<i>number</i>]) | Getter/setter for the animation duration of transitions between states (opening, zoom in/out) in milliseconds. Enter `0` to disable animations. | `800` |
+| <b>disableD3Transitions</b>([<i>boolean</i>]) | Option to disable D3 transition functions which may cause errors on very fast re-renders. | `false` |
 
 ## Data syntax
 

--- a/src/icicle.js
+++ b/src/icicle.js
@@ -37,7 +37,8 @@ export default Kapsule({
     tooltipContent: { default: d => '', triggerUpdate: false },
     onClick: { triggerUpdate: false },
     onHover: { triggerUpdate: false },
-    transitionDuration: { default: 800, triggerUpdate: false }
+    transitionDuration: { default: 800, triggerUpdate: false },
+    disableD3Transitions: { default: false }
   },
   methods: {
     zoomBy: function(state, k) {
@@ -181,7 +182,7 @@ export default Kapsule({
 
     const animate = !state.skipTransitionsOnce;
     state.skipTransitionsOnce = false;
-    const transition = d3Transition().duration(animate ? state.transitionDuration: 0);
+    const transition = state.disableD3Transitions ? null : d3Transition().duration(animate ? state.transitionDuration: 0);
 
     const x0 = { td: d => d.x0, bu: d => d.x0, lr: d => d.y0, rl: d => state.width - d.y1 }[state.orientation];
     const x1 = { td: d => d.x1, bu: d => d.x1, lr: d => d.y1, rl: d => state.width - d.y0 }[state.orientation];

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -80,8 +80,8 @@ export interface IcicleChartGenericInstance<ChainableInstance> {
   transitionDuration(): number;
   transitionDuration(duration: number): ChainableInstance;
 
-  disableD3Transition(): boolean;
-  disableD3Transition(disable: boolean): ChainableInstance;
+  disableD3Transitions(): boolean;
+  disableD3Transitions(disable: boolean): ChainableInstance;
 }
 
 export type IcicleChartInstance = IcicleChartGenericInstance<IcicleChartInstance>;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -79,6 +79,9 @@ export interface IcicleChartGenericInstance<ChainableInstance> {
 
   transitionDuration(): number;
   transitionDuration(duration: number): ChainableInstance;
+
+  disableD3Transition(): boolean;
+  disableD3Transition(disable: boolean): ChainableInstance;
 }
 
 export type IcicleChartInstance = IcicleChartGenericInstance<IcicleChartInstance>;


### PR DESCRIPTION
### Addition of option to chart props: disableD3Transitions()

This pull request adds an extra option to the chart props called "disableD3Transitions" which disables the d3Transition function used in icicle.js. The reason that I think this is necessary is because, while developing my react application using this library, I encountered an issue where d3 transitions throws an error on very fast re-renders of the chart. A solution to this fix is to completely remove the d3 transition function and set the transition value to null. This causes the animation to be default (therefore transitionDuration does not work if disableD3Transition is true), but fixes the fast re-render issue.

Here is an example of the error generated by d3 transitions.

![ERR](https://user-images.githubusercontent.com/104069774/164221060-3d5946f7-5fe2-4a1b-ab73-6722739f4059.png)
