### PR TITLE
Add missing fields to Node type definition

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -7,6 +7,7 @@ export interface Node {
   __dataNode?: DataNode;
   name?: string;
   children?: Node[];
+  [key: string]: any;
 }
 
 export interface DataNode {


### PR DESCRIPTION
This is the same as sunburst-chart uses: https://github.com/vasturiano/sunburst-chart/commit/f7e7c89e606abf436508b64a4d420a24a6dd59fe